### PR TITLE
ms-sys: Add glibc dependency

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,11 +1,12 @@
 pkgbase = ms-sys
 	pkgdesc = Used to create Microsoft compatible boot records
 	pkgver = 2.4.1
-	pkgrel = 2
+	pkgrel = 3
 	url = http://ms-sys.sourceforge.net/
 	arch = i686
 	arch = x86_64
 	license = GPL
+	depends = glibc
 	source = http://prdownloads.sourceforge.net/ms-sys/ms-sys-2.4.1.tar.gz
 	md5sums = d31e7ef3db6bd77dbb13df11057fa0f2
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,14 +1,16 @@
 # Maintainer: polyzen <polycitizen@gmail.com>
+# Contributor: carstene1ns <arch carsten-teibes de>
 # Contributor: <kfgz at interia dot pl>
 # Contributor: <damir at archlinux dot org>
 
 pkgname=ms-sys
 pkgver=2.4.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Used to create Microsoft compatible boot records"
 arch=('i686' 'x86_64')
 url="http://ms-sys.sourceforge.net/"
 license=('GPL')
+depends=('glibc')
 source=(http://prdownloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz)
 md5sums=('d31e7ef3db6bd77dbb13df11057fa0f2')
 


### PR DESCRIPTION
Fixes the following `namcap` warning:
```
ms-sys E: Dependency glibc detected and not included (libraries ['usr/lib/libc.so.6'] needed in files ['usr/bin/ms-sys'])
```
